### PR TITLE
make GWT epub friendly

### DIFF
--- a/user/src/com/google/gwt/layout/client/LayoutImpl.java
+++ b/user/src/com/google/gwt/layout/client/LayoutImpl.java
@@ -54,7 +54,7 @@ class LayoutImpl {
 
   protected static DivElement createRuler(Unit widthUnit, Unit heightUnit) {
     DivElement ruler = Document.get().createDivElement();
-    ruler.setInnerHTML("&nbsp;");
+    ruler.setInnerHTML("&#xA0;");
     Style style = ruler.getStyle();
     style.setPosition(Position.ABSOLUTE);
     style.setZIndex(-32767);

--- a/user/src/com/google/gwt/logging/client/HtmlLogFormatter.java
+++ b/user/src/com/google/gwt/logging/client/HtmlLogFormatter.java
@@ -102,7 +102,7 @@ public class HtmlLogFormatter extends FormatterImpl {
   private String getEscaped(String text) {
     text = text.replaceAll("<", "&lt;");
     text = text.replaceAll(">", "&gt;");
-    text = text.replaceAll("\t", "&nbsp;&nbsp;&nbsp;");
+    text = text.replaceAll("\t", "&#xA0;&#xA0;&#xA0;");
     return text;
   }
 

--- a/user/src/com/google/gwt/user/client/ui/Grid.java
+++ b/user/src/com/google/gwt/user/client/ui/Grid.java
@@ -75,7 +75,7 @@ public class Grid extends HTMLTable {
    */
   private static native void addRows(Element table, int rows, int columns) /*-{
      var td = $doc.createElement("td");
-     td.innerHTML = "&nbsp;";
+     td.innerHTML = "&#xA0;";
      var row = $doc.createElement("tr");
      for(var cellNum = 0; cellNum < columns; cellNum++) {
        var cell = td.cloneNode(true);
@@ -130,7 +130,7 @@ public class Grid extends HTMLTable {
   public boolean clearCell(int row, int column) {
     Element td = getCellFormatter().getElement(row, column);
     boolean b = internalClearCell(td, false);
-    td.setInnerHTML("&nbsp;");
+    td.setInnerHTML("&#xA0;");
     return b;
   }
 
@@ -271,7 +271,7 @@ public class Grid extends HTMLTable {
 
     // Add a non-breaking space to the TD. This ensures that the cell is
     // displayed.
-    td.setInnerHTML("&nbsp;");
+    td.setInnerHTML("&#xA0;");
     return DOM.asOld(td);
   }
 

--- a/user/src/com/google/gwt/user/client/ui/TabBar.java
+++ b/user/src/com/google/gwt/user/client/ui/TabBar.java
@@ -208,7 +208,7 @@ public class TabBar extends Composite implements SourcesTabEvents,
 
     panel.setVerticalAlignment(HasVerticalAlignment.ALIGN_BOTTOM);
 
-    HTML first = new HTML("&nbsp;", true), rest = new HTML("&nbsp;", true);
+    HTML first = new HTML("&#xA0;", true), rest = new HTML("&#xA0;", true);
     first.setStyleName("gwt-TabBarFirst");
     rest.setStyleName("gwt-TabBarRest");
     first.setHeight("100%");


### PR DESCRIPTION
GWT is a great tool to bring interactivity in ebooks to a whole new level. Unfortunately, the epub v3 specs are still based on XHTML... even though the newer bells and whistles of HTML5 are acceptable too.

With respect to GWT, the only issue arises due to the `&nbsp;` character entity, which is not known in `XHTML`. Once replaced by `&#xA0;` everything works like a charm.

This PR does just that by replacing those characters but only where it matters, e.g. no replacements under `test` or `samples`. 